### PR TITLE
Prevent resolver session start to get stuck

### DIFF
--- a/proxybroker/providers.py
+++ b/proxybroker/providers.py
@@ -99,8 +99,7 @@ class Provider:
         except ResolveError:
             return
         connector = aiohttp.TCPConnector(use_dns_cache=True, loop=self._loop)
-        # This is a dirty hack. I know.
-        connector._cached_hosts[(host, 80)] = host_info
+        connector._cached_hosts.add((host, 80), host_info)
         self._session = aiohttp.ClientSession(
             connector=connector, headers=get_headers(),
             cookies=self._cookies, loop=self._loop)


### PR DESCRIPTION
I am not sure why it happens (maybe due to changes in the latest version of aiohttp?), but suddenly `proxybroker` started getting stuck.

I don’t really understand the affected code, but this change seems to solve the issue for me. I hope it helps.
